### PR TITLE
Add error for flight service async

### DIFF
--- a/src/datablocks/data_block.rs
+++ b/src/datablocks/data_block.rs
@@ -39,6 +39,10 @@ impl DataBlock {
         )?)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.num_columns() == 0 || self.num_rows() == 0
+    }
+
     pub fn schema(&self) -> &DataSchemaRef {
         &self.schema
     }

--- a/src/datasources/system/settings_table_test.rs
+++ b/src/datasources/system/settings_table_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_settings_table() -> crate::error::FuseQueryResult<()> {
     use futures::TryStreamExt;
+    use pretty_assertions::assert_eq;
 
     use crate::datasources::system::*;
     use crate::datasources::*;

--- a/src/datavalues/data_array_aggregate_test.rs
+++ b/src/datavalues/data_array_aggregate_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_array_aggregate() {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use super::*;

--- a/src/datavalues/data_array_arithmetic_test.rs
+++ b/src/datavalues/data_array_arithmetic_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_array_arithmetic() {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use super::*;

--- a/src/datavalues/data_array_comparison_test.rs
+++ b/src/datavalues/data_array_comparison_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_array_comparison() {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use super::*;

--- a/src/datavalues/data_array_logic_test.rs
+++ b/src/datavalues/data_array_logic_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_array_logic() {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use super::*;

--- a/src/datavalues/data_value_aggregate_test.rs
+++ b/src/datavalues/data_value_aggregate_test.rs
@@ -4,6 +4,8 @@
 
 #[test]
 fn test_data_value_arithmetic() {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[allow(dead_code)]

--- a/src/datavalues/data_value_arithmetic_test.rs
+++ b/src/datavalues/data_value_arithmetic_test.rs
@@ -4,6 +4,8 @@
 
 #[test]
 fn test_data_value_arithmetic() {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[allow(dead_code)]

--- a/src/functions/aggregators/aggregator_test.rs
+++ b/src/functions/aggregators/aggregator_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_aggregator_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::DataBlock;

--- a/src/functions/arithmetics/arithmetic_test.rs
+++ b/src/functions/arithmetics/arithmetic_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_arithmetic_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::DataBlock;

--- a/src/functions/comparisons/comparison_test.rs
+++ b/src/functions/comparisons/comparison_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_comparison_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::*;

--- a/src/functions/logics/logic_test.rs
+++ b/src/functions/logics/logic_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_logic_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::*;

--- a/src/processors/processor_empty_test.rs
+++ b/src/processors/processor_empty_test.rs
@@ -4,6 +4,8 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_processor_empty() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
+
     use crate::processors::*;
 
     let empty = EmptyProcessor::create();

--- a/src/processors/processor_merge_test.rs
+++ b/src/processors/processor_merge_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_processor_merge() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datavalues::*;

--- a/src/rpcs/rpc/executor_service_test.rs
+++ b/src/rpcs/rpc/executor_service_test.rs
@@ -4,6 +4,8 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_executor_service() -> Result<(), Box<dyn std::error::Error>> {
+    use pretty_assertions::assert_eq;
+
     use crate::protobuf::executor_client::ExecutorClient;
     use crate::protobuf::{PingRequest, PingResponse};
 

--- a/src/rpcs/rpc/flight_service_test.rs
+++ b/src/rpcs/rpc/flight_service_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_service() -> Result<(), Box<dyn std::error::Error>> {
     use futures::TryStreamExt;
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
     use crate::rpcs::rpc::*;

--- a/src/rpcs/rpc/macros.rs
+++ b/src/rpcs/rpc/macros.rs
@@ -1,0 +1,18 @@
+// Copyright 2020-2021 The FuseQuery Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+// Match the result in the async.
+// If error, send the error to the channel.
+// Else, return the value.
+macro_rules! match_async_result {
+    ($VALUE:expr, $SENDER:ident) => {{
+        match ($VALUE) {
+            Err(e) => {
+                $SENDER.send(Err(from_fuse_err(&e))).await.ok();
+                return;
+            }
+            Ok(v) => v,
+        }
+    }};
+}

--- a/src/rpcs/rpc/mod.rs
+++ b/src/rpcs/rpc/mod.rs
@@ -5,6 +5,9 @@
 mod executor_service_test;
 mod flight_service_test;
 
+#[macro_use]
+mod macros;
+
 mod executor_service;
 mod flight_action;
 mod flight_client;

--- a/src/transforms/transform_aggregator_partial.rs
+++ b/src/transforms/transform_aggregator_partial.rs
@@ -10,7 +10,7 @@ use futures::stream::StreamExt;
 
 use crate::datablocks::DataBlock;
 use crate::datastreams::{DataBlockStream, SendableDataBlockStream};
-use crate::datavalues::{DataSchemaRef, DataValue, StringArray};
+use crate::datavalues::{DataField, DataSchema, DataSchemaRef, DataType, DataValue, StringArray};
 use crate::error::FuseQueryResult;
 use crate::functions::IFunction;
 use crate::planners::ExpressionPlan;
@@ -79,12 +79,17 @@ impl IProcessor for AggregatorPartialTransform {
             acc_results.push(serialized);
         }
 
+        let partial_schema = Arc::new(DataSchema::new(vec![DataField::new(
+            "partial_result",
+            DataType::Utf8,
+            false,
+        )]));
         let partial_results = acc_results
             .iter()
             .map(|x| x.as_str())
             .collect::<Vec<&str>>();
         let block = DataBlock::create(
-            self.schema.clone(),
+            partial_schema,
             vec![Arc::new(StringArray::from(partial_results))],
         );
         Ok(Box::pin(DataBlockStream::create(

--- a/src/transforms/transform_aggregator_test.rs
+++ b/src/transforms/transform_aggregator_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_aggregator() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datavalues::*;

--- a/src/transforms/transform_filter_test.rs
+++ b/src/transforms/transform_filter_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_filter() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datavalues::*;

--- a/src/transforms/transform_limit_test.rs
+++ b/src/transforms/transform_limit_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_limit() -> crate::error::FuseQueryResult<()> {
     use futures::TryStreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::planners::*;

--- a/src/transforms/transform_projection_test.rs
+++ b/src/transforms/transform_projection_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_projection() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::planners::*;

--- a/src/transforms/transform_remote_test.rs
+++ b/src/transforms/transform_remote_test.rs
@@ -26,11 +26,9 @@ async fn test_transform_remote_with_local() -> crate::error::FuseQueryResult<()>
     let mut stream = remote.execute().await?;
     while let Some(v) = stream.next().await {
         let v = v?;
-        if v.num_rows() > 0 {
-            let actual = v.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
-            let expect = &UInt64Array::from(vec![99]);
-            assert_eq!(expect.clone(), actual.clone());
-        }
+        let actual = v.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        let expect = &UInt64Array::from(vec![99]);
+        assert_eq!(expect.clone(), actual.clone());
     }
     Ok(())
 }

--- a/src/transforms/transform_remote_test.rs
+++ b/src/transforms/transform_remote_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_remote_with_local() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
+    use pretty_assertions::assert_eq;
 
     use crate::datavalues::*;
     use crate::planners::*;

--- a/src/transforms/transform_remote_test.rs
+++ b/src/transforms/transform_remote_test.rs
@@ -32,3 +32,27 @@ async fn test_transform_remote_with_local() -> crate::error::FuseQueryResult<()>
     }
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_transform_remote() -> crate::error::FuseQueryResult<()> {
+    use futures::stream::StreamExt;
+
+    use crate::datavalues::*;
+    use crate::processors::*;
+    use crate::sql::*;
+
+    let ctx = crate::tests::try_create_context_with_nodes(3).await?;
+    let plan = PlanParser::create(ctx.clone())
+        .build_from_sql("select sum(number+1)+2 as sumx from system.numbers_mt(80000)")?;
+    let mut pipeline = PipelineBuilder::create(ctx, plan).build()?;
+
+    let mut stream = pipeline.execute().await?;
+    while let Some(v) = stream.next().await {
+        let v = v?;
+        println!("{:?}", v);
+        let actual = v.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        let expect = &UInt64Array::from(vec![99]);
+        assert_eq!(expect.clone(), actual.clone());
+    }
+    Ok(())
+}

--- a/src/transforms/transform_source_test.rs
+++ b/src/transforms/transform_source_test.rs
@@ -5,6 +5,7 @@
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn transform_source_test() -> crate::error::FuseQueryResult<()> {
     use futures::TryStreamExt;
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::processors::*;


### PR DESCRIPTION
## Summary

Add error for flight async service, if the pipeline error when exeucted, it will raise to the flight client.

## Changelog

- New Feature

## Related Issues
#53 

## Test Plan

None
