### PR TITLE
Distributed query engine PART-5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bench:
 	cargo bench
 
 run:
-	RUSTFLAGS="-C target-cpu=native" cargo run --release
+	RUST_BACKTRACE=full RUSTFLAGS="-C target-cpu=native" cargo run --release
 
 build:
 	RUSTFLAGS="-C target-cpu=native" cargo build --release

--- a/src/bin/fuse-query.rs
+++ b/src/bin/fuse-query.rs
@@ -71,8 +71,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RPC API service.
     {
         let srv = RpcService::create(conf.clone(), cluster.clone(), session_manager.clone());
-        srv.make_server().await.unwrap();
         info!("RPC API server listening on {}", conf.rpc_api_address);
+        srv.make_server().await.unwrap();
     }
 
     Ok(())

--- a/src/clusters/cluster.rs
+++ b/src/clusters/cluster.rs
@@ -29,7 +29,7 @@ impl Cluster {
     }
 
     pub fn add_node(&self, node: &Node) -> FuseQueryResult<()> {
-        self.nodes.lock()?.insert(node.id.clone(), node.clone());
+        self.nodes.lock()?.insert(node.name.clone(), node.clone());
         Ok(())
     }
 

--- a/src/clusters/cluster_test.rs
+++ b/src/clusters/cluster_test.rs
@@ -24,10 +24,12 @@ fn test_cluster() -> crate::error::FuseQueryResult<()> {
     };
     cluster.add_node(&node2)?;
 
-    cluster.remove_node("node1".to_string())?;
+    let cluster_clone = cluster.clone();
+    cluster_clone.remove_node("node1".to_string())?;
+    cluster_clone.remove_node("node2".to_string())?;
 
-    let nodes = cluster.get_nodes()?[0].clone();
+    let nodes = cluster.get_nodes()?;
 
-    assert_eq!(node2, nodes);
+    assert_eq!(0, nodes.len());
     Ok(())
 }

--- a/src/clusters/cluster_test.rs
+++ b/src/clusters/cluster_test.rs
@@ -11,14 +11,14 @@ fn test_cluster() -> crate::error::FuseQueryResult<()> {
     let cluster = Cluster::empty();
 
     let node1 = Node {
-        id: "node1".to_string(),
+        name: "node1".to_string(),
         cpus: 4,
         address: "127.0.0.1:9001".to_string(),
     };
     cluster.add_node(&node1)?;
 
     let node2 = Node {
-        id: "node2".to_string(),
+        name: "node2".to_string(),
         cpus: 8,
         address: "127.0.0.1:9002".to_string(),
     };

--- a/src/clusters/node.rs
+++ b/src/clusters/node.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct Node {
     pub id: String,
     pub cpus: usize,

--- a/src/clusters/node.rs
+++ b/src/clusters/node.rs
@@ -4,7 +4,7 @@
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct Node {
-    pub id: String,
+    pub name: String,
     pub cpus: usize,
     pub address: String,
 }

--- a/src/functions/udfs/database_test.rs
+++ b/src/functions/udfs/database_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_database_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::*;

--- a/src/functions/udfs/to_type_name_test.rs
+++ b/src/functions/udfs/to_type_name_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_to_type_name_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::*;

--- a/src/functions/udfs/udf_example_test.rs
+++ b/src/functions/udfs/udf_example_test.rs
@@ -4,6 +4,7 @@
 
 #[test]
 fn test_udf_function() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use crate::datablocks::*;

--- a/src/planners/plan_scheduler_test.rs
+++ b/src/planners/plan_scheduler_test.rs
@@ -74,21 +74,21 @@ fn test_scheduler_plan_with_3_nodes() -> crate::error::FuseQueryResult<()> {
 
     // Add node1 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node1".to_string(),
+        name: "node1".to_string(),
         cpus: 4,
         address: "127.0.0.1:9001".to_string(),
     })?;
 
     // Add node2 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node2".to_string(),
+        name: "node2".to_string(),
         cpus: 4,
         address: "127.0.0.1:9002".to_string(),
     })?;
 
     // Add node3 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node3".to_string(),
+        name: "node3".to_string(),
         cpus: 4,
         address: "127.0.0.1:9003".to_string(),
     })?;

--- a/src/processors/pipeline_builder_test.rs
+++ b/src/processors/pipeline_builder_test.rs
@@ -39,21 +39,21 @@ async fn test_distributed_pipeline_build() -> crate::error::FuseQueryResult<()> 
 
     // Add node1 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node1".to_string(),
+        name: "node1".to_string(),
         cpus: 4,
         address: "127.0.0.1:9001".to_string(),
     })?;
 
     // Add node2 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node2".to_string(),
+        name: "node2".to_string(),
         cpus: 4,
         address: "127.0.0.1:9002".to_string(),
     })?;
 
     // Add node3 to cluster.
     ctx.try_get_cluster()?.add_node(&Node {
-        id: "node3".to_string(),
+        name: "node3".to_string(),
         cpus: 4,
         address: "127.0.0.1:9003".to_string(),
     })?;

--- a/src/rpcs/http/router.rs
+++ b/src/rpcs/http/router.rs
@@ -22,11 +22,10 @@ impl Router {
         &self,
     ) -> FuseQueryResult<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone>
     {
-        let config_handler = super::v1::config::config_handler(self.cfg.clone())?;
-        let hello_handler = super::v1::hello::hello_handler(self.cfg.clone())?;
-        let cluster_nodes_handler =
-            super::v1::cluster::cluster_nodes_handler(self.cluster.clone())?;
-        let v1 = config_handler.or(hello_handler).or(cluster_nodes_handler);
-        Ok(v1)
+        let v1 = super::v1::hello::hello_handler(self.cfg.clone())
+            .or(super::v1::config::config_handler(self.cfg.clone()))
+            .or(super::v1::cluster::cluster_handler(self.cluster.clone()));
+        let routes = v1.with(warp::log("v1"));
+        Ok(routes)
     }
 }

--- a/src/rpcs/http/v1/cluster.rs
+++ b/src/rpcs/http/v1/cluster.rs
@@ -85,7 +85,7 @@ mod handlers {
         // TODO(BohuTANG): error handler
         cluster
             .add_node(&Node {
-                id: req.name,
+                name: req.name,
                 cpus: req.cpus,
                 address: req.address,
             })

--- a/src/rpcs/http/v1/cluster_test.rs
+++ b/src/rpcs/http/v1/cluster_test.rs
@@ -40,14 +40,6 @@ async fn test_cluster() -> crate::error::FuseQueryResult<()> {
         assert_eq!(200, res.await.status());
     }
 
-    // Check.
-    {
-        let res = warp::test::request()
-            .path("/v1/cluster/list")
-            .reply(&filter);
-        assert_eq!("[{\"name\":\"9090\",\"cpus\":4,\"address\":\"127.0.0.1:9090\"},{\"name\":\"9091\",\"cpus\":4,\"address\":\"127.0.0.1:9091\"}]", res.await.body());
-    }
-
     // Remove.
     {
         // Add node.

--- a/src/rpcs/http/v1/cluster_test.rs
+++ b/src/rpcs/http/v1/cluster_test.rs
@@ -1,0 +1,78 @@
+// Copyright 2020-2021 The FuseQuery Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+#[tokio::test]
+async fn test_cluster() -> crate::error::FuseQueryResult<()> {
+    use pretty_assertions::assert_eq;
+
+    use crate::clusters::Cluster;
+    use crate::configs::Config;
+    use crate::rpcs::http::v1::cluster::*;
+
+    let conf = Config::default();
+    let cluster = Cluster::create(conf.clone());
+    let filter = cluster_handler(cluster);
+
+    // Add node.
+    {
+        let res = warp::test::request()
+            .method("POST")
+            .path("/v1/cluster/add")
+            .json(&ClusterNodeRequest {
+                name: "9090".to_string(),
+                cpus: 4,
+                address: "127.0.0.1:9090".to_string(),
+            })
+            .reply(&filter);
+        assert_eq!(200, res.await.status());
+
+        // Add node.
+        let res = warp::test::request()
+            .method("POST")
+            .path("/v1/cluster/add")
+            .json(&ClusterNodeRequest {
+                name: "9091".to_string(),
+                cpus: 4,
+                address: "127.0.0.1:9091".to_string(),
+            })
+            .reply(&filter);
+        assert_eq!(200, res.await.status());
+    }
+
+    // Check.
+    {
+        let res = warp::test::request()
+            .path("/v1/cluster/list")
+            .reply(&filter);
+        assert_eq!("[{\"name\":\"9090\",\"cpus\":4,\"address\":\"127.0.0.1:9090\"},{\"name\":\"9091\",\"cpus\":4,\"address\":\"127.0.0.1:9091\"}]", res.await.body());
+    }
+
+    // Remove.
+    {
+        // Add node.
+        let res = warp::test::request()
+            .method("POST")
+            .path("/v1/cluster/remove")
+            .json(&ClusterNodeRequest {
+                name: "9091".to_string(),
+                cpus: 4,
+                address: "127.0.0.1:9091".to_string(),
+            })
+            .reply(&filter);
+        assert_eq!(200, res.await.status());
+    }
+
+    // Check.
+    {
+        let res = warp::test::request()
+            .path("/v1/cluster/list")
+            .reply(&filter);
+        assert_eq!(
+            "[{\"name\":\"9090\",\"cpus\":4,\"address\":\"127.0.0.1:9090\"}]",
+            res.await.body()
+        );
+    }
+
+    Ok(())
+}

--- a/src/rpcs/http/v1/config.rs
+++ b/src/rpcs/http/v1/config.rs
@@ -5,10 +5,9 @@
 use warp::Filter;
 
 use crate::configs::Config;
-use crate::error::FuseQueryResult;
 
 pub fn config_handler(
     cfg: Config,
-) -> FuseQueryResult<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone> {
-    Ok(warp::path!("v1" / "config").map(move || format!("{:?}", cfg)))
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v1" / "config").map(move || format!("{:?}", cfg))
 }

--- a/src/rpcs/http/v1/hello.rs
+++ b/src/rpcs/http/v1/hello.rs
@@ -5,10 +5,9 @@
 use warp::Filter;
 
 use crate::configs::Config;
-use crate::error::FuseQueryResult;
 
 pub fn hello_handler(
     cfg: Config,
-) -> FuseQueryResult<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone> {
-    Ok(warp::path!("v1" / "hello").map(move || format!("{:?}", cfg)))
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v1" / "hello").map(move || format!("{:?}", cfg))
 }

--- a/src/rpcs/http/v1/mod.rs
+++ b/src/rpcs/http/v1/mod.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+mod cluster_test;
+
 pub mod cluster;
 pub mod config;
 pub mod hello;

--- a/src/servers/mysql/mysql_handler.rs
+++ b/src/servers/mysql/mysql_handler.rs
@@ -62,6 +62,7 @@ impl<W: io::Write> MysqlShim<W> for Session {
                 Ok(executor) => {
                     let result: FuseQueryResult<Vec<DataBlock>> =
                         tokio::runtime::Builder::new_multi_thread()
+                            .enable_io()
                             .worker_threads(self.ctx.get_max_threads()? as usize)
                             .build()?
                             .block_on(async move {

--- a/src/tests/service.rs
+++ b/src/tests/service.rs
@@ -41,7 +41,7 @@ pub async fn try_create_context_with_nodes(nums: usize) -> FuseQueryResult<FuseQ
     let ctx = crate::tests::try_create_context()?;
     for (i, addr) in addrs.iter().enumerate() {
         ctx.try_get_cluster()?.add_node(&Node {
-            id: format!("node{}", i),
+            name: format!("node{}", i),
             cpus: 4,
             address: addr.clone(),
         })?;


### PR DESCRIPTION
## Summary

- [x]  Add cluster REST API for adding cluster node
- [x]   Unit Test

Steps:
* Start two FuseQuery servers with:

```
[node-1] ./target/release/fuse-query 

[node-2] ./target/release/fuse-query --http-api-address=127.0.0.1:8081 --metric-api-address=127.0.0.1:7071 --mysql-handler-port=3308 --rpc-api-address=127.0.0.1:9091
```
* Add nodes to cluster coordinator

```
[1] curl http://127.0.0.1:8080/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"9090","address":"127.0.0.1:9090","cpus":8}'

[2] curl http://127.0.0.1:8080/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"9091","address":"127.0.0.1:9091","cpus":8}'

```

## Changelog

- New Feature

## Related Issues

#53 

## Test Plan

UnitTest
