### PR TITLE
Add mertrics for flight service execute

### DIFF
--- a/src/rpcs/rpc/metrics.rs
+++ b/src/rpcs/rpc/metrics.rs
@@ -1,0 +1,5 @@
+// Copyright 2020-2021 The FuseQuery Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub static METRIC_FLIGHT_EXECUTE_COST: &str = "flight.execute.cost";

--- a/src/rpcs/rpc/mod.rs
+++ b/src/rpcs/rpc/mod.rs
@@ -12,6 +12,7 @@ mod executor_service;
 mod flight_action;
 mod flight_client;
 mod flight_service;
+mod metrics;
 
 pub use executor_service::ExecutorRPCService;
 pub use flight_action::{ExecuteAction, ExecutePlanAction, FetchPartitionAction};


### PR DESCRIPTION
## Summary
http://127.0.0.1:7070/

# TYPE flight_execute_cost summary
flight_execute_cost{quantile="0"} 6.856427537
flight_execute_cost{quantile="0.5"} 6.856427537
flight_execute_cost{quantile="0.9"} 6.856427537
flight_execute_cost{quantile="0.95"} 6.856427537
flight_execute_cost{quantile="0.99"} 6.856427537
flight_execute_cost{quantile="0.999"} 6.856427537
flight_execute_cost{quantile="1"} 6.856427537
flight_execute_cost_sum 6.856427537
flight_execute_cost_count 1

## Changelog

- New Feature

## Related Issues

#53 

## Test Plan

None
