### PR TITLE
[rustfmt] introduce custom rustfmt configuration file for fuse

### DIFF
--- a/benches/benchmarks/bench_aggregator.rs
+++ b/benches/benchmarks/bench_aggregator.rs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use criterion::{criterion_group, criterion_main, Criterion};
-
-use fuse_query::datavalues::*;
 use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use fuse_query::datavalues::*;
 
 macro_rules! bench_suit {
     ($C: expr, $OP: expr, $ARR: expr) => {{

--- a/benches/benchmarks/bench_pipeline.rs
+++ b/benches/benchmarks/bench_pipeline.rs
@@ -3,13 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::stream::StreamExt;
-
 use fuse_query::error::FuseQueryResult;
 use fuse_query::interpreters::SelectInterpreter;
 use fuse_query::planners::PlanNode;
 use fuse_query::sessions::FuseQueryContext;
 use fuse_query::sql::PlanParser;
+use futures::stream::StreamExt;
 
 async fn pipeline_executor(sql: &str) -> FuseQueryResult<()> {
     let ctx = FuseQueryContext::try_create()?;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+reorder_imports = true
+group_imports = "StdExternalCrate"

--- a/src/bin/fuse-query.rs
+++ b/src/bin/fuse-query.rs
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use log::info;
-
 use fuse_query::clusters::Cluster;
 use fuse_query::configs::Config;
 use fuse_query::metrics::MetricService;
 use fuse_query::rpcs::{HttpService, RpcService};
 use fuse_query::servers::MySQLHandler;
 use fuse_query::sessions::Session;
+use log::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/datasources/system/functions_table.rs
+++ b/src/datasources/system/functions_table.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datablocks::DataBlock;
 use crate::datasources::{ITable, Partition, Statistics};

--- a/src/datasources/system/numbers_stream.rs
+++ b/src/datasources/system/numbers_stream.rs
@@ -11,16 +11,15 @@ use std::{
     usize,
 };
 
+use arrow::array::ArrayData;
+use arrow::buffer::Buffer;
+use arrow::datatypes::DataType;
 use futures::stream::Stream;
 
 use crate::datablocks::DataBlock;
 use crate::datavalues::{DataSchemaRef, UInt64Array};
 use crate::error::FuseQueryResult;
 use crate::sessions::FuseQueryContextRef;
-
-use arrow::array::ArrayData;
-use arrow::buffer::Buffer;
-use arrow::datatypes::DataType;
 
 #[derive(Debug, Clone)]
 struct BlockRange {

--- a/src/datasources/system/one_table.rs
+++ b/src/datasources/system/one_table.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datablocks::DataBlock;
 use crate::datasources::{ITable, Partition, Statistics};

--- a/src/datasources/system/settings_table.rs
+++ b/src/datasources/system/settings_table.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datablocks::DataBlock;
 use crate::datasources::{ITable, Partition, Statistics};

--- a/src/datasources/system/tables_table.rs
+++ b/src/datasources/system/tables_table.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datablocks::DataBlock;
 use crate::datasources::{ITable, Partition, Statistics};

--- a/src/datasources/table_factory.rs
+++ b/src/datasources/table_factory.rs
@@ -4,14 +4,15 @@
 
 use std::sync::{Arc, Mutex};
 
+use arrow::datatypes::SchemaRef;
+use indexmap::map::IndexMap;
+use lazy_static::lazy_static;
+
 use crate::datasources::local::LocalFactory;
 use crate::datasources::ITable;
 use crate::error::{FuseQueryError, FuseQueryResult};
 use crate::planners::TableOptions;
 use crate::sessions::FuseQueryContextRef;
-use arrow::datatypes::SchemaRef;
-use indexmap::map::IndexMap;
-use lazy_static::lazy_static;
 
 pub struct TableFactory;
 

--- a/src/datastreams/tests.rs
+++ b/src/datastreams/tests.rs
@@ -4,8 +4,9 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_chunk_stream() {
-    use futures::stream::StreamExt;
     use std::sync::Arc;
+
+    use futures::stream::StreamExt;
 
     use crate::datablocks::*;
     use crate::datastreams::*;

--- a/src/datavalues/data_array_aggregate_test.rs
+++ b/src/datavalues/data_array_aggregate_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_array_aggregate() {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/datavalues/data_array_arithmetic_test.rs
+++ b/src/datavalues/data_array_arithmetic_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_array_arithmetic() {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/datavalues/data_array_comparison_test.rs
+++ b/src/datavalues/data_array_comparison_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_array_comparison() {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/datavalues/data_array_logic_test.rs
+++ b/src/datavalues/data_array_logic_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_array_logic() {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/datavalues/data_type.rs
+++ b/src/datavalues/data_type.rs
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::cmp;
+
+use arrow::datatypes;
+
 use crate::datavalues::DataValueArithmeticOperator;
 use crate::error::{FuseQueryError, FuseQueryResult};
-use arrow::datatypes;
-use std::cmp;
 
 pub type DataType = datatypes::DataType;
 

--- a/src/datavalues/mod.rs
+++ b/src/datavalues/mod.rs
@@ -26,24 +26,23 @@ mod data_value_aggregate;
 mod data_value_arithmetic;
 mod data_value_operator;
 
-pub use data_array_aggregate::data_array_aggregate_op;
-pub use data_array_arithmetic::data_array_arithmetic_op;
-pub use data_array_comparison::data_array_comparison_op;
-pub use data_array_logic::data_array_logic_op;
-pub use data_type::numerical_arithmetic_coercion;
-pub use data_type::numerical_coercion;
-pub use data_value_aggregate::data_value_aggregate_op;
-pub use data_value_arithmetic::data_value_arithmetic_op;
-
 pub use data_array::{
     BooleanArray, DataArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
     Int8Array, NullArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
+pub use data_array_aggregate::data_array_aggregate_op;
+pub use data_array_arithmetic::data_array_arithmetic_op;
+pub use data_array_comparison::data_array_comparison_op;
+pub use data_array_logic::data_array_logic_op;
 pub use data_columnar_value::DataColumnarValue;
 pub use data_field::DataField;
 pub use data_schema::{DataSchema, DataSchemaRef};
+pub use data_type::numerical_arithmetic_coercion;
+pub use data_type::numerical_coercion;
 pub use data_type::DataType;
 pub use data_value::{DataValue, DataValueRef};
+pub use data_value_aggregate::data_value_aggregate_op;
+pub use data_value_arithmetic::data_value_arithmetic_op;
 pub use data_value_operator::{
     DataValueAggregateOperator, DataValueArithmeticOperator, DataValueComparisonOperator,
     DataValueLogicOperator,

--- a/src/error_test.rs
+++ b/src/error_test.rs
@@ -19,8 +19,9 @@ fn test_build_errors() {
 fn test_from_error() {
     use std::str::FromStr;
 
-    use crate::error::*;
     use arrow::error::ArrowError;
+
+    use crate::error::*;
 
     let e: FuseQueryError = ArrowError::MemoryError("Out Of Memory".into()).into();
     assert_eq!(

--- a/src/functions/aggregators/aggregator_test.rs
+++ b/src/functions/aggregators/aggregator_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_aggregator_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::DataBlock;
     use crate::datavalues::*;

--- a/src/functions/arithmetics/arithmetic_test.rs
+++ b/src/functions/arithmetics/arithmetic_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_arithmetic_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::DataBlock;
     use crate::datavalues::*;

--- a/src/functions/comparisons/comparison_test.rs
+++ b/src/functions/comparisons/comparison_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_comparison_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::*;
     use crate::datavalues::*;

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use dyn_clone::DynClone;
 use std::fmt;
+
+use dyn_clone::DynClone;
 
 use crate::datablocks::DataBlock;
 use crate::datavalues::{DataColumnarValue, DataSchema, DataType, DataValue};

--- a/src/functions/function_factory.rs
+++ b/src/functions/function_factory.rs
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::sync::{Arc, Mutex};
+
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
-use std::sync::{Arc, Mutex};
 
 use crate::error::{FuseQueryError, FuseQueryResult};
 use crate::functions::aggregators::AggregatorFunction;

--- a/src/functions/logics/logic_test.rs
+++ b/src/functions/logics/logic_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_logic_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::*;
     use crate::datavalues::*;

--- a/src/functions/udfs/database_test.rs
+++ b/src/functions/udfs/database_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_database_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::*;
     use crate::datavalues::*;

--- a/src/functions/udfs/to_type_name_test.rs
+++ b/src/functions/udfs/to_type_name_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_to_type_name_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::*;
     use crate::datavalues::*;

--- a/src/functions/udfs/udf_example_test.rs
+++ b/src/functions/udfs/udf_example_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_udf_function() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datablocks::*;
     use crate::datavalues::*;

--- a/src/interpreters/interpreter_explain.rs
+++ b/src/interpreters/interpreter_explain.rs
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use log::debug;
-use std::sync::Arc;
 
 use crate::datablocks::DataBlock;
 use crate::datastreams::{DataBlockStream, SendableDataBlockStream};

--- a/src/interpreters/interpreter_select.rs
+++ b/src/interpreters/interpreter_select.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datastreams::SendableDataBlockStream;
 use crate::error::FuseQueryResult;

--- a/src/interpreters/interpreter_setting.rs
+++ b/src/interpreters/interpreter_setting.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use crate::datastreams::{DataBlockStream, SendableDataBlockStream};
 use crate::datavalues::{DataField, DataSchema, DataType};

--- a/src/optimizers/optimizer.rs
+++ b/src/optimizers/optimizer.rs
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::collections::HashMap;
+
 use crate::error::FuseQueryResult;
 use crate::optimizers::FilterPushDownOptimizer;
 use crate::planners::{ExpressionPlan, PlanNode};
 use crate::sessions::FuseQueryContextRef;
-use std::collections::HashMap;
 
 pub trait IOptimizer {
     fn name(&self) -> &str;

--- a/src/planners/plan_aggregator_test.rs
+++ b/src/planners/plan_aggregator_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_aggregator_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
 

--- a/src/planners/plan_explain_test.rs
+++ b/src/planners/plan_explain_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_explain_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
 

--- a/src/planners/plan_expression_test.rs
+++ b/src/planners/plan_expression_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_expression_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
 

--- a/src/planners/plan_limit_test.rs
+++ b/src/planners/plan_limit_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_limit_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
 

--- a/src/planners/plan_projection_test.rs
+++ b/src/planners/plan_projection_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_projection_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datavalues::*;
     use crate::planners::*;

--- a/src/planners/plan_scheduler.rs
+++ b/src/planners/plan_scheduler.rs
@@ -2,13 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+
 use crate::datasources::Statistics;
 use crate::datavalues::DataSchema;
 use crate::error::FuseQueryResult;
 use crate::planners::{EmptyPlan, PlanNode, ReadDataSourcePlan};
 use crate::sessions::FuseQueryContextRef;
-use arrow::datatypes::Schema;
-use std::sync::Arc;
 
 pub struct PlanScheduler {}
 

--- a/src/planners/plan_select_test.rs
+++ b/src/planners/plan_select_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_select_wildcard_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::datavalues::*;
     use crate::planners::*;

--- a/src/planners/plan_stage_test.rs
+++ b/src/planners/plan_stage_test.rs
@@ -4,8 +4,9 @@
 
 #[test]
 fn test_stage_plan() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::planners::*;
 

--- a/src/processors/pipe_test.rs
+++ b/src/processors/pipe_test.rs
@@ -4,8 +4,9 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_pipe() -> crate::error::FuseQueryResult<()> {
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
 
     use crate::processors::*;
 

--- a/src/processors/processor_merge_test.rs
+++ b/src/processors/processor_merge_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_processor_merge() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::stream::StreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::datavalues::*;
     use crate::processors::*;

--- a/src/rpcs/rpc/flight_client.rs
+++ b/src/rpcs/rpc/flight_client.rs
@@ -5,12 +5,11 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use prost::Message;
-
 use arrow::datatypes::Schema;
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::Ticket;
+use prost::Message;
 
 use crate::datablocks::DataBlock;
 use crate::datastreams::{DataBlockStream, SendableDataBlockStream};

--- a/src/rpcs/rpc/flight_service.rs
+++ b/src/rpcs/rpc/flight_service.rs
@@ -6,15 +6,14 @@ use std::io::Cursor;
 use std::pin::Pin;
 use std::time::Instant;
 
-use log::debug;
-use metrics::histogram;
-
 use arrow_flight::{
     flight_service_server::{FlightService as Flight, FlightServiceServer as FlightServer},
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
 use futures::{Stream, StreamExt};
+use log::debug;
+use metrics::histogram;
 use prost::Message;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};

--- a/src/servers/mysql/mysql_handler.rs
+++ b/src/servers/mysql/mysql_handler.rs
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use log::{debug, error};
-
-use metrics::histogram;
 use std::time::Instant;
 use std::{io, net};
 
 use futures::stream::StreamExt;
+use log::{debug, error};
+use metrics::histogram;
 use msql_srv::*;
 use threadpool::ThreadPool;
 

--- a/src/servers/mysql/mysql_stream.rs
+++ b/src/servers/mysql/mysql_stream.rs
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use arrow::datatypes::DataType;
+use arrow::util::display::array_value_to_string;
 use msql_srv::*;
 
 use crate::datablocks::DataBlock;
 use crate::error::{FuseQueryError, FuseQueryResult};
-use arrow::datatypes::DataType;
-use arrow::util::display::array_value_to_string;
 
 pub struct MySQLStream {
     blocks: Vec<DataBlock>,

--- a/src/sessions/context.rs
+++ b/src/sessions/context.rs
@@ -4,6 +4,7 @@
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+
 use uuid::Uuid;
 
 use crate::clusters::{Cluster, ClusterRef};

--- a/src/transforms/transform_aggregator_test.rs
+++ b/src/transforms/transform_aggregator_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_aggregator() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::stream::StreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::datavalues::*;
     use crate::planners::{self, *};

--- a/src/transforms/transform_filter_test.rs
+++ b/src/transforms/transform_filter_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_filter() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::stream::StreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::datavalues::*;
     use crate::planners::*;

--- a/src/transforms/transform_limit_test.rs
+++ b/src/transforms/transform_limit_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_limit() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::TryStreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::planners::*;
     use crate::processors::*;

--- a/src/transforms/transform_projection_test.rs
+++ b/src/transforms/transform_projection_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_projection() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::stream::StreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::planners::*;
     use crate::processors::*;

--- a/src/transforms/transform_source_test.rs
+++ b/src/transforms/transform_source_test.rs
@@ -4,9 +4,10 @@
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn transform_source_test() -> crate::error::FuseQueryResult<()> {
+    use std::sync::Arc;
+
     use futures::TryStreamExt;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     use crate::processors::*;
 


### PR DESCRIPTION
## Summary

We must have a standard [rustfmt style](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md) for fuse-query,
this will be checked automatically and  save lots of time for the reviewers.

## Changelog


- Improvement
