### PR TITLE
[workflow] resolve release build fail

### DIFF
--- a/.github/workflows/fusequery-release.yml
+++ b/.github/workflows/fusequery-release.yml
@@ -53,6 +53,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          override: true
+          components: rustfmt, clippy # ensure rustfmt and clippy installed
           target: ${{ matrix.target }}
 
       - name: Cargo build


### PR DESCRIPTION
<!--
Thank you for sending a PR. Thank you for spending time to help improve the FuseQuery project.
-->

## Summary
Currently the fusequery-release action failed in https://github.com/datafuselabs/fuse-query/actions/runs/664914256/workflow
due to cargo build error:  
error running rustfmt: Os { code: 2, kind: NotFound, message: "No such file or directory" }

add rustfmt and clippy to toolchain should resolve the issue

## Changelog
- Build/Testing/Packaging Improvement

## Related Issues

<!--
The issue fixed or related of this patch if have.
-->
resolve https://github.com/datafuselabs/fuse-query/issues/158
## Test Plan

<!--
Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.
-->
